### PR TITLE
Safely read CSS from stdin

### DIFF
--- a/bin/purifycss
+++ b/bin/purifycss
@@ -10,12 +10,14 @@ var files = argv._;
 if (files.length === 0) return printUsage();
 
 var css = files.filter(function(file){
-  return path.extname(file) === '.css';
+  return path.extname(file) === '.css' || file === '-' || file === '/dev/stdin';
 });
+
+if (css.indexOf('-') > -1) css[css.indexOf('-')] = '/dev/stdin';
 if (css.length === 0) return printUsage("css");
 
 var content = files.filter(function(file){
-  return path.extname(file) !== '.css';
+  return path.extname(file) !== '.css' && file !== '-' && file !== '/dev/stdin';
 });
 if (content.length === 0) return printUsage("content");
 
@@ -23,15 +25,10 @@ if (content.length === 0) return printUsage("content");
 var options = {
   minify: !!argv.min,
   info: !!argv.info,
-  output: argv.out
+  output: argv.out || '/dev/stdout'
 };
-
-if (options.output) {
-  purify(content, css, options);
-} else {
-  console.log(purify(content, css, options));
-}
-
+  
+purify(content, css, options);
 
 function printUsage(errorOn) {
   if (errorOn === "css") console.log("usage: purifycss \033[4;31m<css>\033[0m <content> [option ...]");

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "clean-css": "^3.2.10",
     "gonzales": "^1.0.7",
+    "rw": "^0.1.4",
     "underscore": "^1.8.3",
     "yargs": "^3.10.0"
   },

--- a/src/purifycss.js
+++ b/src/purifycss.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('rw');
 var util = require('util');
 var _ = require('underscore');
 var CleanCss = require('clean-css');


### PR DESCRIPTION
This commit allows the CLI to read from stdin when a dash ("-") is given as the CSS filename.

The [rw](https://github.com/mbostock/rw) module will safely read even long input from stdin. When the input/output file isn't stdin/out, rw acts just like the standard fs module.

As a byproduct, using rw also simplifies the flow of writing to stdout.
