### PR TITLE
Meta to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install purify-css
 
 ``` javascript
   // javascript
-  // this example is jquery, but anytime your class name 
+  // this example is jquery, but anytime your class name
   // is together in your javascript, it will work
   $(button).addClass('button-active');
 ```
@@ -43,7 +43,7 @@ npm install purify-css
   // can detect even if class is split
   var half = 'button-';
   $(button).addClass(half + 'active');
-  
+
   // can detect even if class is joined
   var dynamicClass = ['button', 'active'].join('-');
   $(button).addClass(dynamicClass);
@@ -113,6 +113,8 @@ purify(content, css, options, callback);
 
 * **```rejected:```** Logs the CSS rules that were removed if ```true```. Default: ```false```.
 
+* **```errmeta:```** Logs non-CSS information to stderr instead of stdout, for filtering, if ```true```. Default: ```false```.
+
 ##```callback (optional)```
 ##### Type: ```Function```
 
@@ -145,6 +147,7 @@ options:
  --out [filepath]     Filepath to write purified CSS to
  --info               Logs info on how much CSS was removed
  --rejected           Logs the CSS rules that were removed
+ --errmeta            Logs non-CSS information to stderr instead of stdout, for filtering
 
  -h, --help           Prints help (this message) and exits
 ```

--- a/bin/purifycss
+++ b/bin/purifycss
@@ -24,6 +24,7 @@ var options = {
   minify: !!argv.min,
   info: !!argv.info,
   rejected: !!argv.rejected,
+  metaToErr: !!argv.errmeta,
   output: argv.out
 };
 

--- a/src/purifycss.js
+++ b/src/purifycss.js
@@ -65,11 +65,11 @@ var purify = function(searchThrough, css, options, callback){
   }
 
   if(options.info){
-    printInfo(startTime, beginningLength, source.length);
+    printInfo(options.metaToErr, startTime, beginningLength, source.length);
   }
 
   if (options.rejected){
-    printRejected(rejectedSelectorTwigs.concat(rejectedAtRuleTwigs));
+    printRejected(options.metaToErr, rejectedSelectorTwigs.concat(rejectedAtRuleTwigs));
   }
 
   if(!options.output){
@@ -122,20 +122,22 @@ var getRuleString = function(twig){
   return ruleString;
 };
 
-var printInfo = function(startTime, beginningLength, endingLength){
-  console.log('##################################');
-  console.log('Before purify, CSS was ' + beginningLength + ' chars long.');
-  console.log('After purify, CSS is ' + endingLength + ' chars long. (' +
+var printInfo = function(toErr, startTime, beginningLength, endingLength){
+  var logFn = toErr? console.error: console.log;
+  logFn.call(null, '##################################');
+  logFn.call(null, 'Before purify, CSS was ' + beginningLength + ' chars long.');
+  logFn.call(null, 'After purify, CSS is ' + endingLength + ' chars long. (' +
     Math.floor((beginningLength / endingLength * 10)) / 10  + ' times smaller)');
-  console.log('##################################');
-  console.log('This function took: ', new Date() - startTime, 'ms');
+  logFn.call(null, '##################################');
+  logFn.call(null, 'This function took: ', new Date() - startTime, 'ms');
 };
 
-var printRejected = function(rejectedTwigs){
-  console.log('##################################');
-  console.log('Rejected selectors:');
-  console.log(_.map(rejectedTwigs, getRuleString).join('\n'));
-  console.log('##################################');
+var printRejected = function(toErr, rejectedTwigs){
+  var logFn = toErr? console.error: console.log;
+  logFn.call(null, '##################################');
+  logFn.call(null, 'Rejected selectors:');
+  logFn.call(null, _.map(rejectedTwigs, getRuleString).join('\n'));
+  logFn.call(null, '##################################');
 }
 
 var htmlEls = ['h1','h2','h3','h4','h5','h6','a','abbr','acronym','address','applet','area','article','aside','audio','b','base','basefont','bdi','bdo','bgsound','big','blink','blockquote','body','br','button','canvas','caption','center','cite','code','col','colgroup','command','content','data','datalist','dd','del','details','dfn','dialog','dir','div','dl','dt','element','em','embed','fieldset','figcaption','figure','font','footer','form','frame','frameset','head','header','hgroup','hr','html','i','iframe','image','img','input','ins','isindex','kbd','keygen','label','legend','li','link','listing','main','map','mark','marquee','menu','menuitem','meta','meter','multicol','nav','nobr','noembed','noframes','noscript','object','ol','optgroup','option','output','p','param','picture','plaintext','pre','progress','q','rp','rt','rtc','ruby','s','samp','script','section','select','shadow','small','source','spacer','span','strike','strong','style','sub','summary','sup','table','tbody','td','template','textarea','tfoot','th','thead','time','title','tr','track','tt','u','ul','var','video','wbr','xmp'];


### PR DESCRIPTION
Adds `--errmeta` option which tells the lib to output `--info` and `--rejected` information (ie, non-CSS output) to stderr instead of stdout. Allows users to easily filter out stuff that isn't the final CSS, as in:

```bash
$ purifycss my.css my.html my.js --rejected --errmeta >purified.css 2>purified.meta
```