### PR TITLE
Prevent breaking Handlebars, Moustache or Liquid double braces style tags

### DIFF
--- a/src/cssTree.js
+++ b/src/cssTree.js
@@ -258,7 +258,7 @@ var filterSelector = function(branch, classes, htmlEls, ids, attrSelectors){
       return true;
     }
 
-    if (flatTwig.indexOf('pseudoe') > -1 || flatTwig.indexOf('*') > -1 || flatTwig.indexOf('pseudoc') > -1) {
+    if (flatTwig.indexOf('pseudoe') > -1 || flatTwig.indexOf('*') > -1 || flatTwig.indexOf('pseudoc') > -1 || flatTwig.indexOf('attrselector') > -1) {
       return true;
     }
 

--- a/src/cssTree.js
+++ b/src/cssTree.js
@@ -194,6 +194,9 @@ var formatCSS = function(styles){
   styles = styles.split('}\\n\\n').join('}\\n');
   styles = styles.split(' }').join('}');
   styles = styles.split(' }').join('}');
+  // Prevent breaking Handlebars or Moustache double brace style tags
+  styles = styles.split('}\\n}').join(' }}');
+  styles = styles.split('}}\\n').join('}}');
 
   return styles;
 };


### PR DESCRIPTION
Templating languages such as Handlebars, Moustache or Shopify's Liquid use a double brace tagging syntax.
These two lines of code prevent the format after PurifyCSS run to break two consecutive curly braces.

For example, it prevents

    {{ tag }} 

to become 

    {{ tag }
    }

In my case I have this line of code in my css (Shopify's Liquid syntax):

    src: url('{{ \'icomoon.eot?cdxnim\' | asset_url }}');

and PurifyCSS without this patch breaks it in:

    src: url('{{ \'icomoon.eot?cdxnim\' | asset_url }
    }
    ');

Also fixed deletion of selectors like

    [class*=' icon-'] 

