### PR TITLE
Use helper function to reduce repetitive code

### DIFF
--- a/src/cssTree.js
+++ b/src/cssTree.js
@@ -283,29 +283,14 @@ var filterSelector = function(branch, classes, htmlEls, ids, attrSelectors){
 
     var isId = flatTwig.indexOf('shash') > -1;
     if(isId){
-      var validated = validateId(flatTwig, ids);
-      throwDelim = !validated;
-      if(!validated){
-        rejectedTwigs.push(twig);
-      }
-      return validated;
+      return handleValidation(validateId(flatTwig, ids), throwDelim, rejectedTwigs, twig);
     }
 
     var hasClass = flatTwig.indexOf('clazz') > -1;
     if(hasClass){
-      var validated = validateClass(flatTwig, classes);
-      throwDelim = !validated;
-      if(!validated){
-        rejectedTwigs.push(twig);
-      }
-      return validated;
+      return handleValidation(validateClass(flatTwig, classes), throwDelim, rejectedTwigs, twig);
     } else {
-      var validated = validateHtmlTag(flatTwig, htmlEls);
-      throwDelim = !validated;
-      if(!validated){
-        rejectedTwigs.push(twig);
-      }
-      return validated;
+      return handleValidation(validateHtmlTag(flatTwig, htmlEls), throwDelim, rejectedTwigs, twig);
     }
 
     return true;

--- a/src/cssTree.js
+++ b/src/cssTree.js
@@ -239,6 +239,14 @@ var validateHtmlTag = function(flatTwig, htmlEls){
   return false;
 };
 
+var handleValidation = function(validated, throwDelim, rejectedTwigs, twig){
+  throwDelim = !validated;
+  if(validated){
+    rejectedTwigs.push(twig);
+  }
+  return validated;
+};
+
 var filterSelector = function(branch, classes, htmlEls, ids, attrSelectors){
   var throwDelim = false;
   var rejectedTwigs = [];


### PR DESCRIPTION
The same 6 lines of code are repeated three separate times in src/cssTree.js:
```javascript
var validated = validateHtmlTag(flatTwig, htmlEls);
throwDelim = !validated;
if(!validated){
  rejectedTwigs.push(twig);
}
return validated;
```
Where validateHtmlTag() is interchangeable with validateClass() and validateId()

I've implemented a function that consolidates the above 6 lines of code into one place:

```javascript
var handleValidation = function(validated, throwDelim, rejectedTwigs, twig){
  throwDelim = !validated;
  if(validated){
    rejectedTwigs.push(twig);
  }
  return validated;
};
```

After replacing the repetitive code with handleValidation(), I successfully ran 'npm test'. I was also able to use bin/purifycss in the command line successfully.

If you'd like, I can change the name of handleValidation() to something else.

![npm_test](https://cloud.githubusercontent.com/assets/10136907/8714384/139ab278-2b29-11e5-90b1-7c5cd14e1c1e.png)