### PR TITLE
fix: remove unused classes with pseudoelements

### DIFF
--- a/src/cssTree.js
+++ b/src/cssTree.js
@@ -255,7 +255,7 @@ var filterSelector = function(branch, classes, htmlEls, ids, attrSelectors){
       return true;
     }
 
-    if(flatTwig.indexOf('pseudoe') > -1 || flatTwig.indexOf('*') > -1 || flatTwig.indexOf('pseudoc') > -1){
+    if(flatTwig.indexOf('pseudoe') > -1 || flatTwig.indexOf('*') > -1){
       return true;
     }
 

--- a/test/purify_test.js
+++ b/test/purify_test.js
@@ -75,6 +75,14 @@ describe('purify', function(){
     expect(result.indexOf('vertical') > -1).to.equal(true);
   });
 
+  it('works with unused classed with pseudo-elements', function(){
+    var content = "";
+    var css = ".email-address:before { }";
+    var result = purify(content, css);
+
+    expect(result).to.equal("");
+  });
+
   it('works with media queries', function(){
     var content = fs.readFileSync(absPath + 'media_queries/media_queries.js', 'utf8');
     var css = fs.readFileSync(absPath + 'media_queries/media_queries.css', 'utf8');


### PR DESCRIPTION
It seems [this change](https://github.com/purifycss/purifycss/commit/bf3f5526edbf8d68737e170b20a747db4bcd177f) (adding pseudoc) lead to a regression regarding unused classes with pseudoclasses attached.

