### PR TITLE
Add custom element support

### DIFF
--- a/src/cssTree.js
+++ b/src/cssTree.js
@@ -12,6 +12,7 @@ var CssTree = function(cssString){
   this.ids = null;
   this.specialIds = null;
   this.attrSelectors = null;
+  this.customElements = null;
 
   this.initialize(ast);
 };
@@ -33,6 +34,7 @@ CssTree.prototype.initialize = function(ast){
   var classes = [];
   var css = _.flatten(ast.slice());
   var attrSelectors = [];
+  var customElements = [];
 
   for(var i = 0; i < css.length; i++){
     if(css[i] === 'clazz'){
@@ -45,6 +47,10 @@ CssTree.prototype.initialize = function(ast){
 
     if(css[i] === 'shash'){
       ids.push(css[i + 1].toLowerCase());
+    }
+
+    if(css[i] === 'simpleselector' && css[i+1] === 'ident' && css[i+2].indexOf('-') !== -1){
+      customElements.push(css[i+2]);
     }
   }
 
@@ -82,6 +88,7 @@ CssTree.prototype.initialize = function(ast){
   this.classes = _.uniq(normalClasses);
   this.specialClasses = _.uniq(specialClasses);
   this.attrSelectors = attrSelectors;
+  this.customElements = _.uniq(customElements);
 };
 
 CssTree.prototype.filterSelectors = function(classes, htmlEls, ids, attrSelectors){

--- a/src/purifycss.js
+++ b/src/purifycss.js
@@ -48,10 +48,12 @@ var purify = function(searchThrough, css, options, callback){
   var ids = extraction.filter(tree.ids);
   var specialIds = extraction.filterBySearch(tree.specialIds);
   var attrSelectors = extraction.filterBySearch(tree.attrSelectors);
+  var customElements = extraction.filter(tree.customElements);
 
   classes = classes.concat(specialClasses);
   ids = ids.concat(specialIds);
   var usedHtmlEls = extraction.filter(htmlEls);
+  usedHtmlEls = usedHtmlEls.concat(customElements);
 
   // Narrow CSS tree down to things that remain on the list
   var rejectedSelectorTwigs = tree.filterSelectors(classes, usedHtmlEls, ids, attrSelectors);

--- a/test/purify_test.js
+++ b/test/purify_test.js
@@ -107,4 +107,13 @@ describe('purify', function(){
     expect(result.indexOf('+rounded') > -1).to.equal(true);
     expect(result.indexOf('button') > -1).to.equal(true);
   });
+
+  it('works with custom elements', function(){
+    var content = fs.readFileSync(absPath + 'custom_elements/custom_elements.js', 'utf8');
+    var css = fs.readFileSync(absPath + 'custom_elements/custom_elements.css', 'utf8');
+    var result = purify(content, css);
+
+    expect(result.indexOf('foo-bar') > -1).to.equal(true);
+    expect(result.indexOf('bar-foo') > -1).to.equal(false);
+  });
 });

--- a/test/test_examples/custom_elements/custom_elements.css
+++ b/test/test_examples/custom_elements/custom_elements.css
@@ -1,0 +1,7 @@
+foo-bar {
+  text-align: center;
+}
+
+bar-foo {
+  text-align: right;
+}

--- a/test/test_examples/custom_elements/custom_elements.js
+++ b/test/test_examples/custom_elements/custom_elements.js
@@ -1,0 +1,1 @@
+document.registerElement('foo-bar');


### PR DESCRIPTION
This commit will preserve rules for used custom elements. My understanding of [gonzales](https://github.com/css/gonzales) is very limited so the commit might miss some cases where custom elements are used. The code is identifying the pattern ["simpleselector", "ident", <name-with-dash>] which might be incomplete, i.e. some styling rules on custom elements might be removed.