### PR TITLE
Only log rejected selectors if there is something to log.

### DIFF
--- a/src/purifycss.js
+++ b/src/purifycss.js
@@ -70,7 +70,7 @@ var purify = function (searchThrough, css, options, callback) {
     PrintUtil.printInfo(minify(source).length);
   }
 
-  if (options.rejected) {
+  if (options.rejected && selectorFilter.rejectedSelectors.length) {
     PrintUtil.printRejected(selectorFilter.rejectedSelectors);
   }
 


### PR DESCRIPTION
This PR avoids logging an empty rejected selectors notice.