### PR TITLE
Add option: returnRejected

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ var options = {
   minify: true,
 
   // Logs out removed selectors.
-  rejected: true,
+  rejected: true
 };
 
 purify(content, css, options);

--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ var options = {
   minify: true,
 
   // Logs out removed selectors.
-  rejected: true
+  rejected: true,
+  
+  // Will return list of removed selectors instead of the purified CSS.
+  returnRejected: true
 };
 
 purify(content, css, options);

--- a/README.md
+++ b/README.md
@@ -145,9 +145,6 @@ var options = {
 
   // Logs out removed selectors.
   rejected: true,
-  
-  // Will return list of removed selectors instead of the purified CSS.
-  returnRejected: true
 };
 
 purify(content, css, options);
@@ -156,6 +153,21 @@ logs out:
 
 ```
 .unused-class
+```
+
+<br />
+
+##### Example with returnRejected
+
+```js
+var content = '<button class="button-active"> Login </button>';
+var css = '.button-active { color: green; }   .unused-class { display: block; }';
+
+var rejected = purify(content, css, {
+  returnRejected: true
+});
+
+console.log(rejected)
 ```
 
 <br />

--- a/src/purifycss.js
+++ b/src/purifycss.js
@@ -60,6 +60,10 @@ var purify = function (searchThrough, css, options, callback) {
   tree.beginReading();
   var source = tree.toString();
 
+  if (options.returnRejected) {
+    return selectorFilter.rejectedSelectors;
+  }
+
   if (options.minify) {
     source = minify(source);
   }


### PR DESCRIPTION
To use purifycss as a linter only you can use the option `returnRejected` which enables reporting for removed selectors so that we gain control over the output (unlike `rejected`).
