### PR TITLE
Selector regex fix

### DIFF
--- a/bin/purifycss
+++ b/bin/purifycss
@@ -42,9 +42,10 @@ if (options.output) {
 
 function printUsage(errorOn) {
   if (errorOn === 'css') {
-    console.log('usage: purifycss \033[4;31m<css>\033[0m <content> [option ...]');
+    console.log('usage: purifycss \033[4;31m<css>\033[0m <content> [option ...]'); //eslint-disable-line no-octal-escape
   } else if (errorOn === 'content') {
-    console.log('usage: purifycss <css> \033[4;31m<content>\033[0m [option ...]');
+    console.log('usage: purifycss <css> \033[4;31m<content>\033[0m [option ...]'); //eslint-disable-line no-octal-escape
+
   } else {
     console.log('usage: purifycss <css> <content> [option ...]');
   }

--- a/src/utils/ExtractWordsUtil.js
+++ b/src/utils/ExtractWordsUtil.js
@@ -16,7 +16,7 @@ var ExtractWordsUtil = {
     for (var i = 0; i < content.length; i++) {
       var chr = content[i];
 
-      if (chr.match(/-?[_a-z]+[_a-z0-9-]*/i)) {
+      if (chr.match(/[_a-z0-9-]/i)) {
         word += chr;
       } else {
         used[word] = true;
@@ -58,7 +58,7 @@ var ExtractWordsUtil = {
         continue;
       }
 
-      if (letter.match(/-?[_a-z]+[_a-z0-9-]*/i)) {
+      if (letter.match(/[_a-z0-9-]/i)) {
         word += letter;
       } else {
         addWord(words, word);

--- a/src/utils/ExtractWordsUtil.js
+++ b/src/utils/ExtractWordsUtil.js
@@ -16,7 +16,7 @@ var ExtractWordsUtil = {
     for (var i = 0; i < content.length; i++) {
       var chr = content[i];
 
-      if (chr.match(/[a-z]+/)) {
+      if (chr.match(/-?[_a-z]+[_a-z0-9-]*/i)) {
         word += chr;
       } else {
         used[word] = true;
@@ -58,7 +58,7 @@ var ExtractWordsUtil = {
         continue;
       }
 
-      if (letter.match(/[a-z]+/)) {
+      if (letter.match(/-?[_a-z]+[_a-z0-9-]*/i)) {
         word += letter;
       } else {
         addWord(words, word);

--- a/test/purify_test.js
+++ b/test/purify_test.js
@@ -26,6 +26,10 @@ describe('purify', function () {
     it('can find .triple-simple-class', function () {
       expect(this.result.indexOf('.triple-simple-class') > -1).to.equal(true);
     });
+
+    it('can find .Another-11_13', function(){
+     expect(this.result.indexOf('.Another-11_13') > -1).to.equal(true);
+    });
   });
 
   describe('callback', function () {

--- a/test/test_examples/simple/simple.css
+++ b/test/test_examples/simple/simple.css
@@ -9,3 +9,7 @@
 .triple-simple-class {
   color: black;
 }
+
+.Another-11_13 {
+  color: black;
+}

--- a/test/test_examples/simple/simple.js
+++ b/test/test_examples/simple/simple.js
@@ -3,3 +3,5 @@
 'double-class'
 
 'triple-simple-class'
+
+'Another-11_13'


### PR DESCRIPTION
This fix solves the following:
1) eslint octal errors (should be in separate branch really, but I couldn't run the tests without it)
2) faulty selector regex - previously limited to only lowercase letters, now includes all valid css classnames

Note: I didn't do negative testing, so these changes _might_ mean that some other errant selector passes the new regex pattern and gets included when it shouldn't. But I don't think that likely.

EDIT: Hmm, apparently it now allows certain selectors when it shouldn't. Gonna fix that and reopen the PR after I make the changes.