### PR TITLE
Adding options.strict to allow more aggressive removal of unused selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,12 @@ var options = {
   minify: true,
 
   // Logs out removed selectors.
-  rejected: true
+  rejected: true,
+
+  // Uses strict selector matching. Strict selector matching allows for
+  // more agressive removal of styles.
+  // will not match dynamic selectors i.e. ['button', 'active'].join('-')
+  strict: true,
 };
 
 purify(content, css, options);

--- a/src/CssTreeWalker.js
+++ b/src/CssTreeWalker.js
@@ -20,6 +20,7 @@ CssTreeWalker.prototype.constructor = CssTreeWalker;
 CssTreeWalker.prototype.beginReading = function () {
   this.ast = rework(this.startingSource)
     .use(this.readPlugin.bind(this));
+  return this;
 };
 
 CssTreeWalker.prototype.readPlugin = function (tree) {

--- a/src/CssTreeWalker.js
+++ b/src/CssTreeWalker.js
@@ -11,7 +11,7 @@ var CssTreeWalker = function (code, plugins) {
 
   plugins.forEach(function (plugin) {
     plugin.initialize(this);
-  }.bind(this));
+  }, this);
 };
 
 CssTreeWalker.prototype = Object.create(EventEmitter.prototype);
@@ -39,7 +39,7 @@ CssTreeWalker.prototype.readRules = function (rules) {
     if (ruleType === MEDIA_TYPE) {
       this.readRules(rule.rules);
     }
-  }.bind(this));
+  }, this);
 };
 
 CssTreeWalker.prototype.toString = function () {
@@ -66,7 +66,7 @@ CssTreeWalker.prototype.removeEmptyRules = function (rules) {
         emptyRules.push(rule);
       }
     }
-  }.bind(this));
+  }, this);
 
   emptyRules.forEach(function (emptyRule) {
     var index = rules.indexOf(emptyRule);

--- a/src/SelectorFilter.js
+++ b/src/SelectorFilter.js
@@ -39,9 +39,9 @@ SelectorFilter.prototype.parseWhitelist = function (whitelist) {
     } else {
       getAllWordsInSelector(whitelistSelector, this.strict).forEach(function (word) {
         this.contentWords[word] = true;
-      }.bind(this));
+      }, this);
     }
-  }.bind(this));
+  }, this);
 };
 
 SelectorFilter.prototype.parseRule = function (selectors, rule) {

--- a/src/SelectorFilter.js
+++ b/src/SelectorFilter.js
@@ -14,10 +14,11 @@ function hasWhitelistMatch(selector, whitelist) {
   return false;
 }
 
-var SelectorFilter = function (contentWords, whitelist) {
+var SelectorFilter = function (contentWords, whitelist, strict) {
   this.contentWords = contentWords;
   this.rejectedSelectors = [];
   this.wildcardWhitelist = [];
+  this.strict = !!strict;
 
   this.parseWhitelist(whitelist);
 };
@@ -36,7 +37,7 @@ SelectorFilter.prototype.parseWhitelist = function (whitelist) {
         whitelistSelector.substr(1, whitelistSelector.length - 2)
       );
     } else {
-      getAllWordsInSelector(whitelistSelector).forEach(function (word) {
+      getAllWordsInSelector(whitelistSelector, this.strict).forEach(function (word) {
         this.contentWords[word] = true;
       }.bind(this));
     }
@@ -59,7 +60,7 @@ SelectorFilter.prototype.filterSelectors = function (selectors) {
       return;
     }
 
-    var words = getAllWordsInSelector(selector);
+    var words = getAllWordsInSelector(selector, this.strict);
     var usedWords = words.filter(function (word) {
       return contentWords[word];
     });
@@ -69,7 +70,7 @@ SelectorFilter.prototype.filterSelectors = function (selectors) {
     } else {
       rejectedSelectors.push(selector);
     }
-  });
+}, this);
 
   return usedSelectors;
 };

--- a/src/SelectorFilter.js
+++ b/src/SelectorFilter.js
@@ -70,7 +70,7 @@ SelectorFilter.prototype.filterSelectors = function (selectors) {
     } else {
       rejectedSelectors.push(selector);
     }
-}, this);
+  }, this);
 
   return usedSelectors;
 };

--- a/src/purifycss.js
+++ b/src/purifycss.js
@@ -52,13 +52,12 @@ var purify = function (searchThrough, css, options, callback) {
 
   PrintUtil.startLog(minify(cssString).length);
 
-  var wordsInContent = getAllWordsInContent(content);
+  var wordsInContent = getAllWordsInContent(content, options.strict);
 
-  var selectorFilter = new SelectorFilter(wordsInContent, options.whitelist);
+  var selectorFilter = new SelectorFilter(wordsInContent, options.whitelist, options.strict);
 
   var tree = new CssTreeWalker(cssString, [selectorFilter]);
-  tree.beginReading();
-  var source = tree.toString();
+  var source = tree.beginReading().toString();
 
   if (options.minify) {
     source = minify(source);
@@ -70,7 +69,7 @@ var purify = function (searchThrough, css, options, callback) {
     PrintUtil.printInfo(minify(source).length);
   }
 
-  if (options.rejected && selectorFilter.rejectedSelectors.length) {
+  if (options.rejected) {
     PrintUtil.printRejected(selectorFilter.rejectedSelectors);
   }
 

--- a/src/utils/ExtractWordsUtil.js
+++ b/src/utils/ExtractWordsUtil.js
@@ -5,7 +5,7 @@ var addWord = function (words, word) {
 };
 
 var ExtractWordsUtil = {
-  getAllWordsInContent: function (content) {
+  getAllWordsInContent: function (content, strict) {
     var used = {
       // Always include html and body.
       html: true,
@@ -16,10 +16,12 @@ var ExtractWordsUtil = {
     for (var i = 0; i < content.length; i++) {
       var chr = content[i];
 
-      if (chr.match(/[a-z]+/)) {
+      if (chr.match(/[a-z]+/) || (strict && (chr.match(/[0-9\_]+/) || (word.length && chr === '-')))) {
         word += chr;
       } else {
-        used[word] = true;
+        if (word.length && word.match((/[a-z0-9]+/))) {
+            used[word] = true;
+        }
         word = '';
       }
     }
@@ -29,7 +31,7 @@ var ExtractWordsUtil = {
     return used;
   },
 
-  getAllWordsInSelector: function (selector) {
+  getAllWordsInSelector: function (selector, strict) {
     // Remove attr selectors. "a[href...]"" will become "a".
     selector = selector.replace(/\[(.+?)\]/g, '').toLowerCase();
 
@@ -44,22 +46,22 @@ var ExtractWordsUtil = {
     var skipNextWord = false;
 
     for (var i = 0; i < selector.length; i++) {
-      var letter = selector[i];
+      var chr = selector[i];
 
-      if (skipNextWord && (letter !== '.' || letter !== '#' || letter !== ' ')) {
+      if (skipNextWord && (chr !== '.' || chr !== '#' || chr !== ' ')) {
         continue;
       }
 
       // If pseudoclass or universal selector, skip the next word
-      if (letter === ':' || letter === '*') {
+      if (chr === ':' || chr === '*') {
         addWord(words, word);
         word = '';
         skipNextWord = true;
         continue;
       }
 
-      if (letter.match(/[a-z]+/)) {
-        word += letter;
+      if (chr.match(/[a-z]+/) || (strict && (chr.match(/[0-9\_]+/) || (word.length && chr === '-')))) {
+        word += chr;
       } else {
         addWord(words, word);
         word = '';

--- a/src/utils/ExtractWordsUtil.js
+++ b/src/utils/ExtractWordsUtil.js
@@ -20,7 +20,7 @@ var ExtractWordsUtil = {
         word += chr;
       } else {
         if (word.length && word.match((/[a-z0-9]+/))) {
-            used[word] = true;
+          used[word] = true;
         }
         word = '';
       }


### PR DESCRIPTION
Support for calculated class names is nice, but it can allow unused classes to remain. When options.strict is set to true, selectors will be matched fully against full words including '_'. '-', and numbers.