### PR TITLE
add an option to turn off memory saving mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 npm-debug.log
+.vscode

--- a/bin/purifycss
+++ b/bin/purifycss
@@ -31,7 +31,8 @@ var options = {
   minify: !!argv.min,
   info: !!argv.info,
   rejected: !!argv.rejected,
-  output: argv.out
+  output: argv.out,
+  timeSensitive: !!argv['time-sensitive']
 };
 
 if (options.output) {
@@ -42,8 +43,10 @@ if (options.output) {
 
 function printUsage(errorOn) {
   if (errorOn === 'css') {
+    /*eslint no-octal-escape: 0*/
     console.log('usage: purifycss \033[4;31m<css>\033[0m <content> [option ...]');
   } else if (errorOn === 'content') {
+    /*eslint no-octal-escape: 0*/
     console.log('usage: purifycss <css> \033[4;31m<content>\033[0m [option ...]');
   } else {
     console.log('usage: purifycss <css> <content> [option ...]');
@@ -54,6 +57,7 @@ function printUsage(errorOn) {
   console.log(' --out [filepath]     Filepath to write purified css to');
   console.log(' --info               Logs info on how much css was removed');
   console.log(' --rejected           Logs the CSS rules that were removed');
+  console.log(' --time-sensitive     Turn off momory saving mode');
   console.log();
   console.log(' -h, --help           Prints help (this message) and exits');
   console.log();

--- a/src/purifycss.js
+++ b/src/purifycss.js
@@ -26,7 +26,8 @@ var getOptions = function (options) {
     output: false,
     minify: false,
     info: false,
-    whitelist: []
+    whitelist: [],
+    timeSensitive: false
   };
 
   Object.keys(options).forEach(function (option) {
@@ -48,7 +49,7 @@ var purify = function (searchThrough, css, options, callback) {
   options = getOptions(options);
 
   var cssString = FileUtil.filesToSource(css, 'css');
-  var content = FileUtil.filesToSource(searchThrough, 'content');
+  var content = FileUtil.filesToSource(searchThrough, !options.timeSensitive && 'content');
 
   PrintUtil.startLog(minify(cssString).length);
 


### PR DESCRIPTION
Hi,

I notice that purifycss it attempts to compress js files to save memory,  but I don't know if this phase has any other purposes, please correct me if I'm wrong.

I add this option to turn off js compression since in one of my projects some js files pass to purifycss are very large then cause the compression to be very very slow.