### PR TITLE
Match any css selector

### DIFF
--- a/src/utils/ExtractWordsUtil.js
+++ b/src/utils/ExtractWordsUtil.js
@@ -15,8 +15,8 @@ var ExtractWordsUtil = {
 
     for (var i = 0; i < content.length; i++) {
       var chr = content[i];
-
-      if (chr.match(/[a-z]+/)) {
+    //Match any css selector
+      if (chr.match(/[\-0-9_A-Za-z]+/)) {
         word += chr;
       } else {
         used[word] = true;
@@ -57,8 +57,8 @@ var ExtractWordsUtil = {
         skipNextWord = true;
         continue;
       }
-
-      if (letter.match(/[a-z]+/)) {
+    //Match any css selector
+      if (letter.match(/[\-0-9_A-Za-z]+/)) {
         word += letter;
       } else {
         addWord(words, word);


### PR DESCRIPTION
I just had proposed a change some minutes ago but i forgot to add the option when reading the selectors, so i f you had in the html the class "example1" it would only match "example". I just fixed it so it is possible to delete unused selectors with names that include more than just letters, like "example1", "example_2", "example-1"... and any other possibility including of course "example". 
See issue:
https://github.com/purifycss/purifycss/issues/147