### PR TITLE
uglifyjs -> uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "clean-css": "^3.2.10",
     "glob": "^6.0.4",
     "rework": "^1.0.1",
-    "uglifyjs": "^2.4.10",
+    "uglify-js": "^2.8.22",
     "yargs": "^3.10.0"
   },
   "devDependencies": {

--- a/src/utils/FileUtil.js
+++ b/src/utils/FileUtil.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var glob = require('glob');
-var UglifyJS = require('uglifyjs');
+var UglifyJS = require('uglify-js');
 
 var FileUtil = {
   compressCode: function (code) {


### PR DESCRIPTION
replace the deprecated `uglifyjs` with `uglify-js`. 

should silence the installation warnings & the thrown runtime errors.

ref #157 

(build is failing due to seemingly unrelated octal escape codes in `bin/purifycss`)