### PR TITLE
Feature/custom regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ purify(content, css, options, callback);
 
 * **`whitelist`** Array of selectors to always leave in. Ex. `['button-active', '*modal*']` this will leave any selector that includes `modal` in it and selectors that match `button-active`. (wrapping the string with *'s, leaves all selectors that include it)
 
+* **`regex:`** Add custom regex to fit your custom purifying. Ex. `a-z_-`. Default: `a-z`.
 
 
 ##### The (optional) ```callback``` argument

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ purify(content, css, options, callback);
 
 * **`whitelist`** Array of selectors to always leave in. Ex. `['button-active', '*modal*']` this will leave any selector that includes `modal` in it and selectors that match `button-active`. (wrapping the string with *'s, leaves all selectors that include it)
 
-* **`regex:`** Add custom regex to fit your custom purifying. Ex. `a-z_-`. Default: `a-z`.
+* **`regex:`** Add custom characters to the regular expression to fit your custom purifying. Ex. `a-z_-`. Default: `a-z`.
 
 
 ##### The (optional) ```callback``` argument

--- a/lib/purifycss.es.js
+++ b/lib/purifycss.es.js
@@ -780,9 +780,6 @@ var getAllWordsInContent = function getAllWordsInContent(content, options) {
     };
 
     var regex = new RegExp("[^" + options.regex + "]", 'g');
-    console.log('start 1');
-    console.log(regex);
-    console.log('end 1');
     var words = content.split(regex);
 
     var _iteratorNormalCompletion = true;
@@ -826,9 +823,6 @@ var getAllWordsInSelector = function getAllWordsInSelector(selector, options) {
         words = [];
 
     var regex = new RegExp("[" + options.regex + "]");
-    console.log('start 2');
-    console.log(regex);
-    console.log('end 2');
 
     var _iteratorNormalCompletion2 = true;
     var _didIteratorError2 = false;
@@ -948,7 +942,7 @@ var SelectorFilter = function () {
         }
     }, {
         key: "filterSelectors",
-        value: function filterSelectors(selectors, options) {
+        value: function filterSelectors(selectors) {
             var _this2 = this;
 
             var contentWords = this.contentWords,

--- a/lib/purifycss.es.js
+++ b/lib/purifycss.es.js
@@ -747,7 +747,6 @@ var FileUtil = {
     getFilesFromPatternArray: getFilesFromPatternArray
 };
 
-var startTime = void 0;
 var beginningLength = void 0;
 
 var printInfo = function printInfo(endingLength) {
@@ -760,7 +759,6 @@ var printRejected = function printRejected(rejectedTwigs) {
 };
 
 var startLog = function startLog(cssLength) {
-    startTime = new Date();
     beginningLength = cssLength;
 };
 
@@ -774,13 +772,19 @@ var addWord = function addWord(words, word) {
     if (word) words.push(word);
 };
 
-var getAllWordsInContent = function getAllWordsInContent(content) {
+var getAllWordsInContent = function getAllWordsInContent(content, options) {
     var used = {
         // Always include html and body.
         html: true,
         body: true
     };
-    var words = content.split(/[^a-z]/g);
+
+    var regex = new RegExp("[^" + options.regex + "]", 'g');
+    console.log('start 1');
+    console.log(regex);
+    console.log('end 1');
+    var words = content.split(regex);
+
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
     var _iteratorError = undefined;
@@ -809,7 +813,7 @@ var getAllWordsInContent = function getAllWordsInContent(content) {
     return used;
 };
 
-var getAllWordsInSelector = function getAllWordsInSelector(selector) {
+var getAllWordsInSelector = function getAllWordsInSelector(selector, options) {
     // Remove attr selectors. "a[href...]"" will become "a".
     selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase();
     // If complex attr selector (has a bracket in it) just leave
@@ -820,6 +824,11 @@ var getAllWordsInSelector = function getAllWordsInSelector(selector) {
     var skipNextWord = false,
         word = "",
         words = [];
+
+    var regex = new RegExp("[" + options.regex + "]");
+    console.log('start 2');
+    console.log(regex);
+    console.log('end 2');
 
     var _iteratorNormalCompletion2 = true;
     var _didIteratorError2 = false;
@@ -837,7 +846,7 @@ var getAllWordsInSelector = function getAllWordsInSelector(selector) {
                 skipNextWord = true;
                 continue;
             }
-            if (/[a-z]/.test(letter)) {
+            if (regex.test(letter)) {
                 word += letter;
             } else {
                 addWord(words, word);
@@ -898,13 +907,14 @@ var hasWhitelistMatch = function hasWhitelistMatch(selector, whitelist) {
 };
 
 var SelectorFilter = function () {
-    function SelectorFilter(contentWords, whitelist) {
+    function SelectorFilter(contentWords, options) {
         classCallCheck(this, SelectorFilter);
 
         this.contentWords = contentWords;
+        this.options = options;
         this.rejectedSelectors = [];
         this.wildcardWhitelist = [];
-        this.parseWhitelist(whitelist);
+        this.parseWhitelist();
     }
 
     createClass(SelectorFilter, [{
@@ -914,9 +924,10 @@ var SelectorFilter = function () {
         }
     }, {
         key: "parseWhitelist",
-        value: function parseWhitelist(whitelist) {
+        value: function parseWhitelist() {
             var _this = this;
 
+            var whitelist = this.options.whitelist;
             whitelist.forEach(function (whitelistSelector) {
                 whitelistSelector = whitelistSelector.toLowerCase();
 
@@ -924,7 +935,7 @@ var SelectorFilter = function () {
                     // If '*button*' then push 'button' onto list.
                     _this.wildcardWhitelist.push(whitelistSelector.substr(1, whitelistSelector.length - 2));
                 } else {
-                    getAllWordsInSelector(whitelistSelector).forEach(function (word) {
+                    getAllWordsInSelector(whitelistSelector, _this.options).forEach(function (word) {
                         _this.contentWords[word] = true;
                     });
                 }
@@ -937,7 +948,9 @@ var SelectorFilter = function () {
         }
     }, {
         key: "filterSelectors",
-        value: function filterSelectors(selectors) {
+        value: function filterSelectors(selectors, options) {
+            var _this2 = this;
+
             var contentWords = this.contentWords,
                 rejectedSelectors = this.rejectedSelectors,
                 wildcardWhitelist = this.wildcardWhitelist,
@@ -948,7 +961,7 @@ var SelectorFilter = function () {
                     usedSelectors.push(selector);
                     return;
                 }
-                var words = getAllWordsInSelector(selector),
+                var words = getAllWordsInSelector(selector, _this2.options),
                     usedWords = words.filter(function (word) {
                     return contentWords[word];
                 });
@@ -973,7 +986,8 @@ var OPTIONS = {
     info: false,
     rejected: false,
     whitelist: [],
-    cleanCssOptions: {}
+    cleanCssOptions: {},
+    regex: 'a-z'
 };
 
 var getOptions = function getOptions() {
@@ -999,8 +1013,8 @@ var purify = function purify(searchThrough, css, options, callback) {
     var cssString = FileUtil.filesToSource(css, "css"),
         content = FileUtil.filesToSource(searchThrough, "content");
     PrintUtil.startLog(minify(cssString).length);
-    var wordsInContent = getAllWordsInContent(content),
-        selectorFilter = new SelectorFilter(wordsInContent, options.whitelist),
+    var wordsInContent = getAllWordsInContent(content, options),
+        selectorFilter = new SelectorFilter(wordsInContent, options),
         tree = new CssTreeWalker(cssString, [selectorFilter]);
     tree.beginReading();
     var source = tree.toString();

--- a/lib/purifycss.js
+++ b/lib/purifycss.js
@@ -784,9 +784,6 @@ var getAllWordsInContent = function getAllWordsInContent(content, options) {
     };
 
     var regex = new RegExp("[^" + options.regex + "]", 'g');
-    console.log('start 1');
-    console.log(regex);
-    console.log('end 1');
     var words = content.split(regex);
 
     var _iteratorNormalCompletion = true;
@@ -830,9 +827,6 @@ var getAllWordsInSelector = function getAllWordsInSelector(selector, options) {
         words = [];
 
     var regex = new RegExp("[" + options.regex + "]");
-    console.log('start 2');
-    console.log(regex);
-    console.log('end 2');
 
     var _iteratorNormalCompletion2 = true;
     var _didIteratorError2 = false;
@@ -952,7 +946,7 @@ var SelectorFilter = function () {
         }
     }, {
         key: "filterSelectors",
-        value: function filterSelectors(selectors, options) {
+        value: function filterSelectors(selectors) {
             var _this2 = this;
 
             var contentWords = this.contentWords,

--- a/lib/purifycss.js
+++ b/lib/purifycss.js
@@ -751,7 +751,6 @@ var FileUtil = {
     getFilesFromPatternArray: getFilesFromPatternArray
 };
 
-var startTime = void 0;
 var beginningLength = void 0;
 
 var printInfo = function printInfo(endingLength) {
@@ -764,7 +763,6 @@ var printRejected = function printRejected(rejectedTwigs) {
 };
 
 var startLog = function startLog(cssLength) {
-    startTime = new Date();
     beginningLength = cssLength;
 };
 
@@ -778,13 +776,19 @@ var addWord = function addWord(words, word) {
     if (word) words.push(word);
 };
 
-var getAllWordsInContent = function getAllWordsInContent(content) {
+var getAllWordsInContent = function getAllWordsInContent(content, options) {
     var used = {
         // Always include html and body.
         html: true,
         body: true
     };
-    var words = content.split(/[^a-z]/g);
+
+    var regex = new RegExp("[^" + options.regex + "]", 'g');
+    console.log('start 1');
+    console.log(regex);
+    console.log('end 1');
+    var words = content.split(regex);
+
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
     var _iteratorError = undefined;
@@ -813,7 +817,7 @@ var getAllWordsInContent = function getAllWordsInContent(content) {
     return used;
 };
 
-var getAllWordsInSelector = function getAllWordsInSelector(selector) {
+var getAllWordsInSelector = function getAllWordsInSelector(selector, options) {
     // Remove attr selectors. "a[href...]"" will become "a".
     selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase();
     // If complex attr selector (has a bracket in it) just leave
@@ -824,6 +828,11 @@ var getAllWordsInSelector = function getAllWordsInSelector(selector) {
     var skipNextWord = false,
         word = "",
         words = [];
+
+    var regex = new RegExp("[" + options.regex + "]");
+    console.log('start 2');
+    console.log(regex);
+    console.log('end 2');
 
     var _iteratorNormalCompletion2 = true;
     var _didIteratorError2 = false;
@@ -841,7 +850,7 @@ var getAllWordsInSelector = function getAllWordsInSelector(selector) {
                 skipNextWord = true;
                 continue;
             }
-            if (/[a-z]/.test(letter)) {
+            if (regex.test(letter)) {
                 word += letter;
             } else {
                 addWord(words, word);
@@ -902,13 +911,14 @@ var hasWhitelistMatch = function hasWhitelistMatch(selector, whitelist) {
 };
 
 var SelectorFilter = function () {
-    function SelectorFilter(contentWords, whitelist) {
+    function SelectorFilter(contentWords, options) {
         classCallCheck(this, SelectorFilter);
 
         this.contentWords = contentWords;
+        this.options = options;
         this.rejectedSelectors = [];
         this.wildcardWhitelist = [];
-        this.parseWhitelist(whitelist);
+        this.parseWhitelist();
     }
 
     createClass(SelectorFilter, [{
@@ -918,9 +928,10 @@ var SelectorFilter = function () {
         }
     }, {
         key: "parseWhitelist",
-        value: function parseWhitelist(whitelist) {
+        value: function parseWhitelist() {
             var _this = this;
 
+            var whitelist = this.options.whitelist;
             whitelist.forEach(function (whitelistSelector) {
                 whitelistSelector = whitelistSelector.toLowerCase();
 
@@ -928,7 +939,7 @@ var SelectorFilter = function () {
                     // If '*button*' then push 'button' onto list.
                     _this.wildcardWhitelist.push(whitelistSelector.substr(1, whitelistSelector.length - 2));
                 } else {
-                    getAllWordsInSelector(whitelistSelector).forEach(function (word) {
+                    getAllWordsInSelector(whitelistSelector, _this.options).forEach(function (word) {
                         _this.contentWords[word] = true;
                     });
                 }
@@ -941,7 +952,9 @@ var SelectorFilter = function () {
         }
     }, {
         key: "filterSelectors",
-        value: function filterSelectors(selectors) {
+        value: function filterSelectors(selectors, options) {
+            var _this2 = this;
+
             var contentWords = this.contentWords,
                 rejectedSelectors = this.rejectedSelectors,
                 wildcardWhitelist = this.wildcardWhitelist,
@@ -952,7 +965,7 @@ var SelectorFilter = function () {
                     usedSelectors.push(selector);
                     return;
                 }
-                var words = getAllWordsInSelector(selector),
+                var words = getAllWordsInSelector(selector, _this2.options),
                     usedWords = words.filter(function (word) {
                     return contentWords[word];
                 });
@@ -977,7 +990,8 @@ var OPTIONS = {
     info: false,
     rejected: false,
     whitelist: [],
-    cleanCssOptions: {}
+    cleanCssOptions: {},
+    regex: 'a-z'
 };
 
 var getOptions = function getOptions() {
@@ -1003,8 +1017,8 @@ var purify = function purify(searchThrough, css, options, callback) {
     var cssString = FileUtil.filesToSource(css, "css"),
         content = FileUtil.filesToSource(searchThrough, "content");
     PrintUtil.startLog(minify(cssString).length);
-    var wordsInContent = getAllWordsInContent(content),
-        selectorFilter = new SelectorFilter(wordsInContent, options.whitelist),
+    var wordsInContent = getAllWordsInContent(content, options),
+        selectorFilter = new SelectorFilter(wordsInContent, options),
         tree = new CssTreeWalker(cssString, [selectorFilter]);
     tree.beginReading();
     var source = tree.toString();

--- a/src/SelectorFilter.js
+++ b/src/SelectorFilter.js
@@ -12,18 +12,20 @@ const hasWhitelistMatch = (selector, whitelist) => {
 }
 
 class SelectorFilter {
-    constructor(contentWords, whitelist) {
+    constructor(contentWords, options) {
         this.contentWords = contentWords
+	    this.options = options
         this.rejectedSelectors = []
         this.wildcardWhitelist = []
-        this.parseWhitelist(whitelist)
+        this.parseWhitelist()
     }
 
     initialize(CssSyntaxTree) {
         CssSyntaxTree.on("readRule", this.parseRule.bind(this))
     }
 
-    parseWhitelist(whitelist) {
+    parseWhitelist() {
+    	const whitelist = this.options.whitelist;
         whitelist.forEach(whitelistSelector => {
             whitelistSelector = whitelistSelector.toLowerCase()
 
@@ -33,7 +35,7 @@ class SelectorFilter {
                     whitelistSelector.substr(1, whitelistSelector.length - 2)
                 )
             } else {
-                getAllWordsInSelector(whitelistSelector).forEach(word => {
+                getAllWordsInSelector(whitelistSelector, this.options).forEach(word => {
                     this.contentWords[word] = true
                 })
             }
@@ -55,7 +57,7 @@ class SelectorFilter {
                 usedSelectors.push(selector)
                 return
             }
-            let words = getAllWordsInSelector(selector),
+            let words = getAllWordsInSelector(selector, this.options),
                 usedWords = words.filter(word => contentWords[word])
 
             if (usedWords.length === words.length) {

--- a/src/purifycss.js
+++ b/src/purifycss.js
@@ -12,7 +12,8 @@ const OPTIONS = {
     info: false,
     rejected: false,
     whitelist: [],
-    cleanCssOptions: {}
+    cleanCssOptions: {},
+    regex: '[a-z]'
 }
 
 const getOptions = (options = {}) => {

--- a/src/purifycss.js
+++ b/src/purifycss.js
@@ -13,7 +13,7 @@ const OPTIONS = {
     rejected: false,
     whitelist: [],
     cleanCssOptions: {},
-    regex: '[a-z]'
+    regex: 'a-z'
 }
 
 const getOptions = (options = {}) => {
@@ -37,8 +37,8 @@ const purify = (searchThrough, css, options, callback) => {
     let cssString = FileUtil.filesToSource(css, "css"),
         content = FileUtil.filesToSource(searchThrough, "content")
     PrintUtil.startLog(minify(cssString).length)
-    let wordsInContent = getAllWordsInContent(content),
-        selectorFilter = new SelectorFilter(wordsInContent, options.whitelist),
+    let wordsInContent = getAllWordsInContent(content, options),
+        selectorFilter = new SelectorFilter(wordsInContent, options),
         tree = new CssTreeWalker(cssString, [selectorFilter])
     tree.beginReading()
     let source = tree.toString()

--- a/src/utils/ExtractWordsUtil.js
+++ b/src/utils/ExtractWordsUtil.js
@@ -8,7 +8,10 @@ export const getAllWordsInContent = content => {
         html: true,
         body: true
     }
-    const words = content.split(/[^a-z]/g)
+    const options = getOptions();
+	const regex = new RegExp("[^" + options.regex + "]",'g');
+	const words = content.split(regex);
+
     for (let word of words) {
         used[word] = true
     }
@@ -27,6 +30,9 @@ export const getAllWordsInSelector = selector => {
         word = "",
         words = []
 
+	const options = getOptions();
+	const regex = new RegExp("[" + options.regex + "]");
+
     for (let letter of selector) {
         if (skipNextWord && !(/[ #.]/).test(letter)) continue
         // If pseudoclass or universal selector, skip the next word
@@ -36,7 +42,7 @@ export const getAllWordsInSelector = selector => {
             skipNextWord = true
             continue
         }
-        if (/[a-z]/.test(letter)) {
+        if (regex.test(letter)) {
             word += letter
         } else {
             addWord(words, word)

--- a/src/utils/ExtractWordsUtil.js
+++ b/src/utils/ExtractWordsUtil.js
@@ -2,13 +2,13 @@ const addWord = (words, word) => {
     if (word) words.push(word)
 }
 
-export const getAllWordsInContent = content => {
+export const getAllWordsInContent = (content, options) => {
     let used = {
         // Always include html and body.
         html: true,
         body: true
     }
-    const options = getOptions();
+
 	const regex = new RegExp("[^" + options.regex + "]",'g');
 	const words = content.split(regex);
 
@@ -18,7 +18,7 @@ export const getAllWordsInContent = content => {
     return used
 }
 
-export const getAllWordsInSelector = selector => {
+export const getAllWordsInSelector = (selector, options) => {
     // Remove attr selectors. "a[href...]"" will become "a".
     selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase()
     // If complex attr selector (has a bracket in it) just leave
@@ -30,7 +30,6 @@ export const getAllWordsInSelector = selector => {
         word = "",
         words = []
 
-	const options = getOptions();
 	const regex = new RegExp("[" + options.regex + "]");
 
     for (let letter of selector) {


### PR DESCRIPTION
I ran into a problem where not enough classes from the Foundation FrameWork were filtered. So i decided to make some adjustments to the purifying plugin. 

I also found an outdated pull request to stricter purifying (https://github.com/purifycss/purifycss/pull/139 ). I figured out that it would be usefull if people could write their own regex to fit their own needs. 

This features add the option to modify the regex expression to purify the css. For me this saved up to **~ 33.6%** instead of only **~ 8.7%**. This makes big sense to me. 

You can use it option by adding the option `regex` to your config file. By default the regex splits words on everything which is not `a-z`. By adjusting the regex to `a-z_-` it doesn't split whole classes in half any longer.  

Use for example:
```
purifycss: {
	options: {
		regex: 'a-z_-' // default: 'a-z'
	}
}
```

So instead of accepting `.block-padding` and `.block-padding-vertical` when only `.block-padding` is used. It now filters `.block-padding-vertical` since this one is not used. 

This also means that you can filter a lot of unused Foundation Framework classes like:
```
.large-offset-0
.large-offset-1
.large-offset-2
.large-offset-3
.large-offset-4
.large-offset-5
...
```

I hope you find this usefull and accept my request. 
