### PR TITLE
Don't minify for printing size if --info is not requested

### DIFF
--- a/lib/purifycss.es.js
+++ b/lib/purifycss.es.js
@@ -811,10 +811,10 @@ var getAllWordsInContent = function getAllWordsInContent(content) {
 
 var getAllWordsInSelector = function getAllWordsInSelector(selector) {
     // Remove attr selectors. "a[href...]"" will become "a".
-    selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase();
+    selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase
     // If complex attr selector (has a bracket in it) just leave
     // the selector in. ¯\_(ツ)_/¯
-    if (selector.includes("[") || selector.includes("]")) {
+    ();if (selector.includes("[") || selector.includes("]")) {
         return [];
     }
     var skipNextWord = false,
@@ -998,7 +998,9 @@ var purify = function purify(searchThrough, css, options, callback) {
     options = getOptions(options);
     var cssString = FileUtil.filesToSource(css, "css"),
         content = FileUtil.filesToSource(searchThrough, "content");
-    PrintUtil.startLog(minify(cssString).length);
+    if (options.info) {
+        PrintUtil.startLog(minify(cssString).length);
+    }
     var wordsInContent = getAllWordsInContent(content),
         selectorFilter = new SelectorFilter(wordsInContent, options.whitelist),
         tree = new CssTreeWalker(cssString, [selectorFilter]);

--- a/lib/purifycss.js
+++ b/lib/purifycss.js
@@ -815,10 +815,10 @@ var getAllWordsInContent = function getAllWordsInContent(content) {
 
 var getAllWordsInSelector = function getAllWordsInSelector(selector) {
     // Remove attr selectors. "a[href...]"" will become "a".
-    selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase();
+    selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase
     // If complex attr selector (has a bracket in it) just leave
     // the selector in. ¯\_(ツ)_/¯
-    if (selector.includes("[") || selector.includes("]")) {
+    ();if (selector.includes("[") || selector.includes("]")) {
         return [];
     }
     var skipNextWord = false,
@@ -1002,7 +1002,9 @@ var purify = function purify(searchThrough, css, options, callback) {
     options = getOptions(options);
     var cssString = FileUtil.filesToSource(css, "css"),
         content = FileUtil.filesToSource(searchThrough, "content");
-    PrintUtil.startLog(minify(cssString).length);
+    if (options.info) {
+        PrintUtil.startLog(minify(cssString).length);
+    }
     var wordsInContent = getAllWordsInContent(content),
         selectorFilter = new SelectorFilter(wordsInContent, options.whitelist),
         tree = new CssTreeWalker(cssString, [selectorFilter]);

--- a/src/purifycss.js
+++ b/src/purifycss.js
@@ -35,7 +35,9 @@ const purify = (searchThrough, css, options, callback) => {
     options = getOptions(options)
     let cssString = FileUtil.filesToSource(css, "css"),
         content = FileUtil.filesToSource(searchThrough, "content")
-    PrintUtil.startLog(minify(cssString).length)
+    if (options.info) {
+        PrintUtil.startLog(minify(cssString).length)
+    }
     let wordsInContent = getAllWordsInContent(content),
         selectorFilter = new SelectorFilter(wordsInContent, options.whitelist),
         tree = new CssTreeWalker(cssString, [selectorFilter])


### PR DESCRIPTION
https://github.com/purifycss/purifycss/blob/d8a29b4fe89324086cccb83b25f3b30c8d214ed6/src/purifycss.js#L38

This line was always minifying the input with `clean-css`, and then
discarding it if `options.info` was not set.

Running purifycss without `options.info` on a
[small app using tachyons](https://github.com/choojs/bankai/tree/master/example):

  - Before: 302.531ms
  - After: 133.599ms

(Built bundle.js and bundle.css files used for this comparison: https://gist.github.com/goto-bus-stop/40b6b39ed34bd215c8dd0ed274cd2230)