### PR TITLE
add test for pseudo class ":not".

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -251,4 +251,8 @@ describe("pseudo classes", () => {
     it("removes row:after", () => {
         expect(result.includes("row:after") === true).toBe(false)
     })
+
+    it("finds div:not(.foo)", () => {
+        expect(result.includes(":not(.foo)") === true).toBe(true)
+    })
 })

--- a/__tests__/test_examples/pseudo_class/pseudo_class.css
+++ b/__tests__/test_examples/pseudo_class/pseudo_class.css
@@ -5,3 +5,7 @@ div:before {
 .row:after {
   color: black;
 }
+
+div:not(.foo) {
+  color: black;
+}


### PR DESCRIPTION
purifycss removes styles whose selector contains `:not` selector. (See [this issue](https://github.com/purifycss/purifycss/issues/161).)

I added a test for pseudo class `:not`. the test fails.

It seems that `filterSelectors` function in `lib/purifycss.js` judges wrongly about selectors which contain `:not` because words length in a selector and detected words from content length does not be same.
Please do some handling for selectors which have pseudo class `:not`.